### PR TITLE
Improve batch decomposition

### DIFF
--- a/gausspy/batch_decomposition.py
+++ b/gausspy/batch_decomposition.py
@@ -4,27 +4,16 @@ import signal
 import numpy as np
 import AGD_decomposer
 from gp import GaussianDecomposer
-
-# BUG FIXED:  UnboundLocalError: local variable 'result' referenced before assignment
-# Caused by using more threads than spectra.
+from functools import partial
 
 def init_worker():
     """ Worker initializer to ignore Keyboard interrupt """
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-
-
-def init():
-    global agd_object, science_data_path, ilist, agd_data
-    [agd_object, science_data_path, ilist] = pickle.load(open('batchdecomp_temp.pickle'))
-    agd_data = pickle.load(open(science_data_path))
-    if ilist == None: ilist = np.arange(len(agd_data['x_values']))
-
-
-def decompose_one(i):
+def decompose_one(agd_object,agd_data,i):
     print '   ---->  ', i 
     try:
-        result = GaussianDecomposer.decompose(agd_object, 
+    	result = GaussianDecomposer.decompose(agd_object, 
                                           agd_data['x_values'][i], 
                                           agd_data['data_list'][i], 
                                           agd_data['errors'][i])
@@ -37,15 +26,14 @@ def decompose_one(i):
 
 
 
-def func():
-
+def func(agd_object,agd_data, ilist):
  # Multiprocessing code
     ncpus = multiprocessing.cpu_count()
     p = multiprocessing.Pool(ncpus, init_worker)
     if agd_object.p['verbose']: print 'N CPUs: ', ncpus
+    decompose = partial(decompose_one,agd_object, agd_data)
     try:
-        results_list = p.map(decompose_one, ilist, chunksize=1)
-
+        results_list = p.map(decompose, ilist, chunksize=1)
     except KeyboardInterrupt:
         print "KeyboardInterrupt... quitting."
         p.terminate()
@@ -53,5 +41,3 @@ def func():
     p.close()
     del p
     return results_list
-
-

--- a/gausspy/batch_decomposition.py
+++ b/gausspy/batch_decomposition.py
@@ -23,10 +23,16 @@ def init():
 
 def decompose_one(i):
     print '   ---->  ', i 
-    result = GaussianDecomposer.decompose(agd_object, 
+    try:
+        result = GaussianDecomposer.decompose(agd_object, 
                                           agd_data['x_values'][i], 
                                           agd_data['data_list'][i], 
                                           agd_data['errors'][i])
+    except:
+        result = {}
+        result['N_components']=0
+        result['initial_parameters']=[]
+        result['best_fit_errors']=[]
     return result
 
 
@@ -38,7 +44,7 @@ def func():
     p = multiprocessing.Pool(ncpus, init_worker)
     if agd_object.p['verbose']: print 'N CPUs: ', ncpus
     try:
-        results_list = p.map(decompose_one, ilist)
+        results_list = p.map(decompose_one, ilist, chunksize=1)
 
     except KeyboardInterrupt:
         print "KeyboardInterrupt... quitting."


### PR DESCRIPTION
Make files run in order as opposed to however Multiprocessing assigns them - no obvious difference in time, but more debuggable

Catch the cases of failure of a single bad input