### PR TITLE
Improve batch decomposition

### DIFF
--- a/gausspy/batch_decomposition.py
+++ b/gausspy/batch_decomposition.py
@@ -4,42 +4,36 @@ import signal
 import numpy as np
 import AGD_decomposer
 from gp import GaussianDecomposer
-
-# BUG FIXED:  UnboundLocalError: local variable 'result' referenced before assignment
-# Caused by using more threads than spectra.
+from functools import partial
 
 def init_worker():
     """ Worker initializer to ignore Keyboard interrupt """
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-
-
-def init():
-    global agd_object, science_data_path, ilist, agd_data
-    [agd_object, science_data_path, ilist] = pickle.load(open('batchdecomp_temp.pickle'))
-    agd_data = pickle.load(open(science_data_path))
-    if ilist == None: ilist = np.arange(len(agd_data['x_values']))
-
-
-def decompose_one(i):
+def decompose_one(agd_object,agd_data,i):
     print '   ---->  ', i 
-    result = GaussianDecomposer.decompose(agd_object, 
+    try:
+    	result = GaussianDecomposer.decompose(agd_object, 
                                           agd_data['x_values'][i], 
                                           agd_data['data_list'][i], 
                                           agd_data['errors'][i])
+    except:
+        result = {}
+        result['N_components']=0
+        result['initial_parameters']=[]
+        result['best_fit_errors']=[]
     return result
 
 
 
-def func():
-
+def func(agd_object,agd_data, ilist):
  # Multiprocessing code
     ncpus = multiprocessing.cpu_count()
     p = multiprocessing.Pool(ncpus, init_worker)
     if agd_object.p['verbose']: print 'N CPUs: ', ncpus
+    decompose = partial(decompose_one,agd_object, agd_data)
     try:
-        results_list = p.map(decompose_one, ilist)
-
+        results_list = p.map(decompose, ilist, chunksize=1)
     except KeyboardInterrupt:
         print "KeyboardInterrupt... quitting."
         p.terminate()

--- a/gausspy/batch_decomposition.py
+++ b/gausspy/batch_decomposition.py
@@ -26,7 +26,7 @@ def decompose_one(agd_object,agd_data,verbose,i):
 
 
 
-def func(agd_object,agd_data,verbose=False,ilist):
+def func(agd_object,agd_data,verbose,ilist):
  # Multiprocessing code
     ncpus = multiprocessing.cpu_count()
     p = multiprocessing.Pool(ncpus, init_worker)

--- a/gausspy/batch_decomposition.py
+++ b/gausspy/batch_decomposition.py
@@ -10,8 +10,8 @@ def init_worker():
     """ Worker initializer to ignore Keyboard interrupt """
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-def decompose_one(agd_object,agd_data,i):
-    print '   ---->  ', i 
+def decompose_one(agd_object,agd_data,verbose,i):
+    if verbose: print '   ---->  ', i 
     try:
     	result = GaussianDecomposer.decompose(agd_object, 
                                           agd_data['x_values'][i], 
@@ -26,14 +26,14 @@ def decompose_one(agd_object,agd_data,i):
 
 
 
-def func(agd_object,agd_data, ilist):
+def func(agd_object,agd_data,verbose=False,ilist):
  # Multiprocessing code
     ncpus = multiprocessing.cpu_count()
     p = multiprocessing.Pool(ncpus, init_worker)
     if agd_object.p['verbose']: print 'N CPUs: ', ncpus
-    decompose = partial(decompose_one,agd_object, agd_data)
+    decompose = partial(decompose_one,agd_object, agd_data,verbose)
     try:
-        results_list = p.map(decompose, ilist, chunksize=1)
+        results_list = p.map(decompose, ilist)
     except KeyboardInterrupt:
         print "KeyboardInterrupt... quitting."
         p.terminate()

--- a/gausspy/gp.py
+++ b/gausspy/gp.py
@@ -126,14 +126,14 @@ class GaussianDecomposer(object):
 
 
 
-    def batch_decomposition(self, agd_data,ilist=None):
+    def batch_decomposition(self, agd_data,verbose=False,ilist=None):
         """ Science data sould be AGD format 
             ilist is either None or an integer list"""
         
         import batch_decomposition
         if isinstance(agd_data, basestring): agd_data = pickle.load(open(agd_data))
         if ilist == None: ilist = np.arange(len(agd_data['x_values']))
-        result_list = batch_decomposition.func(self,agd_data, ilist)
+        result_list = batch_decomposition.func(self,agd_data, verbose,ilist)
         print 'SUCCESS'
 
         new_keys = ['index_fit', 'amplitudes_fit', 'fwhms_fit', 'means_fit',

--- a/gausspy/gp.py
+++ b/gausspy/gp.py
@@ -126,15 +126,14 @@ class GaussianDecomposer(object):
 
 
 
-    def batch_decomposition(self, science_data_path, ilist=None):
+    def batch_decomposition(self, agd_data,ilist=None):
         """ Science data sould be AGD format 
             ilist is either None or an integer list"""
         
-        # Dump information to hard drive to allow multiprocessing
-        pickle.dump([self, science_data_path, ilist], open('batchdecomp_temp.pickle','w'))
         import batch_decomposition
-        batch_decomposition.init()
-        result_list = batch_decomposition.func()
+        if isinstance(agd_data, basestring): agd_data = pickle.load(open(agd_data))
+        if ilist == None: ilist = np.arange(len(agd_data['x_values']))
+        result_list = batch_decomposition.func(self,agd_data, ilist)
         print 'SUCCESS'
 
         new_keys = ['index_fit', 'amplitudes_fit', 'fwhms_fit', 'means_fit',


### PR DESCRIPTION
Catch the cases of failure of a single bad input
Remove global variables and unnecessary dumping, make it possible to load data directly without dumping it first