### PR TITLE
Python 3.8 compatibility fix

### DIFF
--- a/docs/hybrid.rst
+++ b/docs/hybrid.rst
@@ -1,4 +1,4 @@
-.. _hybrid-example-tutorial:
+.. _hybrid:
 
 ============================================
 Application: 21 cm Absorption & Emission Fit

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Welcome to GaussPy's documentation!
 
 
 .. toctree::
-   :maxdepth: 2
+   :hidden
 
    intro
    install

--- a/gausspy/batch_decomposition.py
+++ b/gausspy/batch_decomposition.py
@@ -9,6 +9,8 @@ import multiprocessing
 import signal
 import numpy as np
 
+import sys
+
 # from . import AGD_decomposer
 from .gp import GaussianDecomposer
 from tqdm import tqdm
@@ -16,6 +18,11 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 
 # BUG FIXED:  UnboundLocalError: local variable 'result' referenced before assignment
 # Caused by using more threads than spectra.
+
+#  With Python 3.8 the start method for multiprocessing defaults to 'spawn' for
+#  MacOS systems. Here we change it back to 'fork' for compatibility reasons.
+if sys.version_info[:2] >= (3, 8):
+    multiprocessing.set_start_method("fork", force=True)
 
 
 def init_worker():


### PR DESCRIPTION
Following gausspyplus (thanks, Manuel!), fixed bug which made the parallel processing break in python 3.8.