### PR TITLE
Edited tunable parameters in hybrid fit

### DIFF
--- a/docs/hybrid.rst
+++ b/docs/hybrid.rst
@@ -116,7 +116,9 @@ The fit then proceeds in a similar manner as in the standard AGD fit:
 
     # Set emission parameters
     g.set('alpha_em', 3.75)
-    g.set('wiggle', 10)
+    g.set('max_tb', None)
+    g.set('p_width', 10)
+    g.set('d_mean', 2)
     g.set('min_dv', 10)
     g.set('drop_width', 3)
     g.set('SNR_em', 3)

--- a/docs/hybrid.rst
+++ b/docs/hybrid.rst
@@ -75,16 +75,27 @@ These include:
 1. ``alpha_em``: the regularization parameter governing the AGD fit to the
 emission residuals.
 
-2. ``wiggle``: the percentage by which the absorption component widths and positions
-are allowed to vary in the fit to emission (e.g., 10%)
+2. ``max_tb``: the maximum brightness temperature absorption components are
+allowed to have in emission. If set to a value, the maximum will be this value.
+If set to "max" (string), the maximum Tb will be computed from the maximum
+kinetic temperature assuming the absorption width and amplitude. If set to None
+(the default), no max will be applied.
 
-3. ``min_dv``: the minimum FWHM of the emission-only components (used to avoid fitting
+3. ``p_width``: the percentage by which the absorption component widths
+are allowed to vary in the fit to emission (e.g., if set to 0.1, the widths
+are allowed to vary by +/-10%). Default = 10%
+
+4. ``d_mean``: the absolute number of channels the absorption components are
+allowed to vary in the fit to emission (e.g., if set to 2, the mean positions
+are allowed to vary by +/-2 channels). Default = 2
+
+5. ``min_dv``: the minimum FWHM of the emission-only components (used to avoid fitting
 unrealistically narrow components in emission which should be recovered in absorption).
 
-4. ``drop_width``: if an emission component is fit by AGD within this number of
+6. ``drop_width``: if an emission component is fit by AGD within this number of
 channels from the position of a fitted absorption component, it will be discarded.
 
-5. ``SNR_em``: the signal-to-noise ratio limit for the emission components.
+7. ``SNR_em``: the signal-to-noise ratio limit for the emission components.
 
 The fit then proceeds in a similar manner as in the standard AGD fit:
 

--- a/gausspy/gp.py
+++ b/gausspy/gp.py
@@ -26,7 +26,9 @@ class GaussianDecomposer(object):
                 "SNR2_thresh": 5.0,
                 "SNR_thresh": 5.0,
                 "SNR_em": 5.0,
-                "wiggle": 0.1,
+                "max_tb": None,
+                "p_width": 0.1,
+                "d_mean": 2,
                 "drop_width": 10,
                 "min_dv": 0,
                 "deblend": True,
@@ -146,9 +148,7 @@ class GaussianDecomposer(object):
             a1 = 10 ** self.p["alpha1"]
             a2 = 10 ** self.p["alpha2"] if self.p["phase"] == "two" else None
             aem = 10 ** self.p["alpha_em"]
-            wgle = self.p["wiggle"]
-            dw = self.p["drop_width"]
-            mdv = self.p["min_dv"]
+
         else:
             a1 = self.p["alpha1"]
             a2 = self.p["alpha2"] if self.p["phase"] == "two" else None
@@ -165,7 +165,9 @@ class GaussianDecomposer(object):
             alpha1=a1,
             alpha2=a2,
             alpha_em=aem,
-            wiggle=self.p["wiggle"],
+            max_tb=self.p["max_tb"],
+            p_width=self.p["p_width"],
+            d_mean=self.p["d_mean"],
             drop_width=self.p["drop_width"],
             min_dv=self.p["min_dv"],
             phase=self.p["phase"],
@@ -179,6 +181,7 @@ class GaussianDecomposer(object):
             perform_final_fit=self.p["perform_final_fit"],
             # plot=self.p["plot"],
         )
+
         return results
 
     def status(self):
@@ -208,8 +211,8 @@ class GaussianDecomposer(object):
             print("Given key does not exist.")
 
     def save_state(self, filename, clobber=False):
-        """ Save the current decomposer object, and all
-             associated parameters to a python pickle file."""
+        """Save the current decomposer object, and all
+        associated parameters to a python pickle file."""
 
         if os.path.isfile(filename):
             if clobber:
@@ -220,8 +223,8 @@ class GaussianDecomposer(object):
         pickle.dump(self, open(filename, "wb"))
 
     def batch_decomposition(self, science_data_path, ilist=None):
-        """ Science data sould be AGD format
-            ilist is either None or an integer list"""
+        """Science data sould be AGD format
+        ilist is either None or an integer list"""
 
         # Dump information to hard drive to allow multiprocessing
         pickle.dump(
@@ -258,7 +261,6 @@ class GaussianDecomposer(object):
         output_data = dict((key, []) for key in new_keys)
 
         for i, result in enumerate(result_list):
-            # print(result.keys())
             # print(result)
             # Save best-fit parameters
             ncomps = result["N_components"]


### PR DESCRIPTION
Expanded upon the tunable parameters in the application case of fitting HI absorption and emission pairs simultaneously. A maximum brightness temperature can now be included ("max_tb"), and whereas previously the parameter "wiggle" controlled the percentage change in both the widths and mean positions of absorption components in the fit to emission, this is now broken into two parameters, p_width (percentage change in the widths) and d_mean (absolute change in the mean positions, in units of channels). 